### PR TITLE
Update SRA-Download.ipynb

### DIFF
--- a/tutorials/notebooks/SRADownload/SRA-Download.ipynb
+++ b/tutorials/notebooks/SRADownload/SRA-Download.ipynb
@@ -413,8 +413,8 @@
     }
    ],
    "source": [
-    "!for i in {1..9}; do echo \"SRR1408688$i\"; done > list_of_accesionIDS.txt\n",
-    "!cat list_of_accesionIDS.txt"
+    "!for i in {1..9}; do echo \"SRR1408688$i\"; done > ~/NIHCloudLabGCP/tutorials/notebooks/SRADownload/data/list_of_accesionIDS.txt\n",
+    "!cat ~/NIHCloudLabGCP/tutorials/notebooks/SRADownload/data/list_of_accesionIDS.txt"
    ]
   },
   {


### PR DESCRIPTION
Added global path (~/NIHCloudLabGCP/tutorials/notebooks/SRADownload/data/) to list_of_accesionIDS.txt in cell 6 so that it writes to the data/ directory instead of the SRADownload/ directory.