### PR TITLE
Spelling change to 'deprecated'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _We have pulled together a variety of tutorials here from disparate sources. Som
 + [Long Read Sequencing Analysis](#long)
 + [Drug Discovery](#atom)
 + [Using Google Batch](#gbatch)
-+ [Using the Life Sciences API (depreciated)](#lsapi)
++ [Using the Life Sciences API (deprecated)](#lsapi)
 + [Public Data Sets](#pub)
 
 ## **Biomedical Workflows on GCP** <a name="bds"></a>
@@ -121,8 +121,8 @@ These notebooks were created to run in Google Colab, so if you run them in Googl
 ## **Using Google Batch** <a name="gbatch"></a>
 You can interact with Google Batch directly to submit commands, or more commonly you can interact with it through orchestration engines like [Nextflow](https://www.Nextflow.io/docs/latest/google.html) and [Cromwell](https://cromwell.readthedocs.io/en/latest/backends/GCPBatch/), etc. We have tutorials that utilize Google Batch using [Nextflow](/notebooks/GoogleBatch/nextflow) where we run the nf-core Methylseq pipeline, as well as several from the NIGMS Sandbox including [transcriptome assembly](https://github.com/NIGMS/rnaAssemblyMDI), [multiomics](https://github.com/NIGMS/MultiomicsUND), [methylseq](https://github.com/NIGMS/MethylSeqUH), and [metagenomics](https://github.com/NIGMS/MetagenomicsUSD).
 
-## **Using the Life Sciences API (depreciated)** <a name="lsapi"></a>
-__Life Science API is depreciated on GCP and will no longer be available by July 8, 2025 on the platform,__ we recommend using Google Batch instead. For now you can still interact with the Life Sciences API directly to submit commands, or more commonly you can interact with it through orchestration engines like [Snakemake](https://snakemake.readthedocs.io/en/v7.0.0/executor_tutorial/google_lifesciences.html), as of now this workflow manager only supports Life Sciences API.
+## **Using the Life Sciences API (deprecated)** <a name="lsapi"></a>
+__Life Science API is deprecated on GCP and will no longer be available by July 8, 2025 on the platform,__ we recommend using Google Batch instead. For now you can still interact with the Life Sciences API directly to submit commands, or more commonly you can interact with it through orchestration engines like [Snakemake](https://snakemake.readthedocs.io/en/v7.0.0/executor_tutorial/google_lifesciences.html), as of now this workflow manager only supports Life Sciences API.
 
 ## **Public Data Sets** <a name="pub"></a>
 Google has a lot of public datasets available that you can use for your testing. These can be viewed [here](https://cloud.google.com/life-sciences/docs/resources/public-datasets) and can be accessed via [BigQuery](https://cloud.google.com/bigquery/public-data) or directly from the cloud bucket. For example, to view Phase 3 1k Genomes at the command line type `gsutil ls gs://genomics-public-data/1000-genomes-phase-3`. 

--- a/notebooks/GoogleBatch/nextflow/Part1_GBatch_Nextflow.ipynb
+++ b/notebooks/GoogleBatch/nextflow/Part1_GBatch_Nextflow.ipynb
@@ -20,7 +20,7 @@
     "__How does Batch differ from Cloud Life Sciences?__ <br>\n",
     "You don't need to configure and manage third-party job schedulers, provision and deprovision resources, or request resources one zone at a time. To run a job, you specify parameters for the resources required for your workload, then Batch obtains resources and queues the job for execution. Batch provides native integration with other Google Cloud services to aid in the scheduling, execution, storage, and analysis of batch jobs.\n",
     "\n",
-    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is depreciated and will no longer be available on GCP by July 8, 2025. </div>\n",
+    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is deprecated and will no longer be available on GCP by July 8, 2025. </div>\n",
     "\n",
     "Here we are going to walk through submitting simple jobs directly to Google Batch, then dive into interacting with Google Batch using Nextflow. We will run some basic Hello World jobs, then move to a more complex [nf-core Methylseq workflow](https://nf-co.re/methylseq). "
    ]
@@ -614,7 +614,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/LifeSciencesAPI/nextflow/Part1_LS_API_Nextflow.ipynb
+++ b/notebooks/LifeSciencesAPI/nextflow/Part1_LS_API_Nextflow.ipynb
@@ -16,7 +16,7 @@
    "id": "d5aa78f4-b8f7-4fbd-846c-09142ac36891",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is depreciated and will no longer be avaible by July 8, 2025 on the platform. Please switch to the <a href=\"../../GoogleBatch/nextflow/Part1_GBatch_Nextflow.ipynb\">Google Batch Nextflow tutorials</a>. </div>"
+    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is deprecated and will no longer be avaible by July 8, 2025 on the platform. Please switch to the <a href=\"../../GoogleBatch/nextflow/Part1_GBatch_Nextflow.ipynb\">Google Batch Nextflow tutorials</a>. </div>"
    ]
   },
   {
@@ -438,7 +438,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/LifeSciencesAPI/nextflow/Part2_LS_API_Nextflow.ipynb
+++ b/notebooks/LifeSciencesAPI/nextflow/Part2_LS_API_Nextflow.ipynb
@@ -16,7 +16,7 @@
    "id": "9eab068b-fed8-4f80-b80f-32d538cb41c7",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is depreciated and will no longer be available by July 8, 2025 on the platform. Please switch to the <a href=\"../../GoogleBatch/nextflow/Part2_GBatch_Nextflow.ipynb\">Google Batch Nextflow tutorials</a>. </div>"
+    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is deprecated and will no longer be available by July 8, 2025 on the platform. Please switch to the <a href=\"../../GoogleBatch/nextflow/Part2_GBatch_Nextflow.ipynb\">Google Batch Nextflow tutorials</a>. </div>"
    ]
   },
   {
@@ -373,7 +373,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/LifeSciencesAPI/snakemake/LS_API_Snakemake.ipynb
+++ b/notebooks/LifeSciencesAPI/snakemake/LS_API_Snakemake.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "This short tutorial demonstrates how to run an RNA-Seq workflow using a prokaryotic data set. Steps in the workflow include read trimming, read QC, read mapping, and counting mapped reads per gene to quantitate gene expression. This tutorial uses a popular workflow manager called [Snakemake](https://snakemake.readthedocs.io/en/stable/) run via the [Google Cloud Life Sciences API](https://cloud.google.com/life-sciences/docs/reference/rest).\n",
     "\n",
-    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is depreciated and has been replaced by Google Batch. Currently Snakemake only supports Google Life Sciences API which will no longer be available by July 8, 2025, visit <a href=\"https://snakemake.readthedocs.io/en/stable/executing/cloud.html\">Snakemake Cloud Execution</a> for updates and instruction for utilizing Google Batch. </div>"
+    "<div class=\"alert alert-block alert-danger\"> <b>Warning:</b> Google Life Sciences API is deprecated and has been replaced by Google Batch. Currently Snakemake only supports Google Life Sciences API which will no longer be available by July 8, 2025, visit <a href=\"https://snakemake.readthedocs.io/en/stable/executing/cloud.html\">Snakemake Cloud Execution</a> for updates and instruction for utilizing Google Batch. </div>"
    ]
   },
   {
@@ -565,7 +565,11 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
### Description
Use of the word "depreciated" in repo is incorrect and should use "deprecated" instead to describe deprecated API.
